### PR TITLE
Set sortOrder parameter as optional in queryItems of SparkGameDataService

### DIFF
--- a/typings/SparkGameDataService.d.ts
+++ b/typings/SparkGameDataService.d.ts
@@ -21,7 +21,7 @@ interface SparkGameDataService {
     /**
      * Queries the indices for a number of items that match the supplied condition. Queries are eventually consistent. If you use queryItems immediately after you've inserted data, you might not get the expected results returned.
      */
-    queryItems(type: string, condition: SparkDataCondition, sortOrder: SparkDataSortOrder): SparkDataQueryResult
+    queryItems(type: string, condition: SparkDataCondition, sortOrder?: SparkDataSortOrder): SparkDataQueryResult
     /**
      * A sort builder for ordering query results
      */


### PR DESCRIPTION
Sort order is optional when calling queryItems on SparkGameDataService