### PR TITLE
Add SparkRequests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,3 +8,79 @@ declare type ScriptableObject = any;
 declare type List = any[];
 
 declare const Spark: Spark;
+
+declare namespace SparkRequests {
+
+    export class AcceptChallengeRequest  {
+
+        public challengeInstanceId : string;
+        public message : string;
+        // tslint:disable-next-line:no-empty
+        public SendAs(playerId : string) : any;
+        // tslint:disable-next-line:no-empty
+    }
+
+    // tslint:disable-next-line: max-classes-per-file
+    export class SteamConnectRequest  {
+
+        public action : string;
+        public matchShortCode : string;
+        public skill : number;
+        public sessionTicket : any;
+        public matchData : any;
+        // tslint:disable-next-line:no-empty
+        public Send() : any;
+        // tslint:disable-next-line:no-empty
+        public SendAs(playerId : string) : any;
+    }
+
+    // tslint:disable-next-line: max-classes-per-file
+    export class MatchmakingRequest  {
+
+        public action : String;
+        public matchShortCode : string;
+        public skill : number;
+        public matchData : any;
+        // tslint:disable-next-line:no-empty
+        public Send() : any;
+        // tslint:disable-next-line:no-empty
+        public SendAs(playerId : string) : any;
+    }
+
+    // tslint:disable-next-line: max-classes-per-file
+    export class LogChallengeEventRequest  {
+        public challengeInstanceId : string;
+        public eventKey : string;
+        // tslint:disable-next-line:no-empty
+        public Send() : any;
+        // tslint:disable-next-line:no-empty
+        public SendAs(playerId : string) : any;
+        public ExecuteAs(playerId : string) : any;
+
+    }
+
+    // tslint:disable-next-line: max-classes-per-file
+    export class CreateChallengeRequest  {
+
+        public accessType : string;
+        public challengeShortCode : string;
+        public endTime : string;
+        public expiryTime : string;
+        public usersToChallenge : any;
+        // tslint:disable-next-line:no-empty
+        public Execute() : any;
+        // tslint:disable-next-line:no-empty
+    }
+
+    // tslint:disable-next-line: max-classes-per-file
+    export class ChangeUserDetailsRequest  {
+
+        public challengeInstanceId : string;
+        public displayName : string;
+        // tslint:disable-next-line:no-empty
+        public SendAs(playerId : string) : any;
+        // tslint:disable-next-line:no-empty
+        public Send() : any;
+    }
+
+}


### PR DESCRIPTION
This pr adds couple of spark requests, these are described like the SteamConnectRequest in seperate pages on [gamesparks api docs](https://docs.gamesparks.com/api-documentation/request-api/authentication/steamconnectrequest.html) (bottom of the page).

SteamConnectRequest would look like this in cloud code:
```
var request = new SparkRequests.SteamConnectRequest();
    request.doNotCreateNewPlayer = ...;
    request.doNotLinkToCurrentPlayer = ...;
    request.errorOnSwitch = ...;
    request.language = ...;
    request.segments = ...;
    request.sessionTicket = ...;
    request.switchIfPossible = ...;
    request.syncDisplayName = ...;
    var response = request.Send();
```
I'm not an expert on defining typescript types., if you could give a some advice on how to separate this better I would really appreciate it and would update pr appropriately.


